### PR TITLE
Update Revolution's app store page from Play Store to F-Droid

### DIFF
--- a/content/_guides/clients.md
+++ b/content/_guides/clients.md
@@ -40,7 +40,7 @@ Some commonly chosen graphical clients for personal computers are are
 [Textual](https://www.codeux.com/textual/) (MacOS).
 
 On phones,
-[Revolution](https://play.google.com/store/apps/details?id=io.mrarm.irc) is
+[Revolution](https://f-droid.org/de/packages/io.mrarm.irc/) is
 commonly used by Android users, and
 [LimeChat](https://apps.apple.com/ch/app/limechat-irc-client/id298766460) is
 popular with iOS users.

--- a/content/_guides/clients.md
+++ b/content/_guides/clients.md
@@ -40,9 +40,9 @@ Some commonly chosen graphical clients for personal computers are are
 [Textual](https://www.codeux.com/textual/) (MacOS).
 
 On phones,
-[Revolution](https://f-droid.org/de/packages/io.mrarm.irc/) is
+[Revolution](https://f-droid.org/packages/io.mrarm.irc/) is
 commonly used by Android users, and
-[LimeChat](https://apps.apple.com/ch/app/limechat-irc-client/id298766460) is
+[LimeChat](https://apps.apple.com/app/limechat-irc-client/id298766460) is
 popular with iOS users.
 
 ### Terminal clients


### PR DESCRIPTION
Since the Revolution IRC client has an official F-Droid store release we should prefer linking to that, instead of the corporate Google Play store (also the Play store does't even care to show the projects license).

Alternatively we could also link both, Play Store and F-Droid. Or even just link to Revolutions official web presence.

But personally I'd prefer just exchanging the link for the F-Droid page as done in my PR :)