### PR TITLE
Update certfp.md to improve file permissions.

### DIFF
--- a/content/_guides/certfp.md
+++ b/content/_guides/certfp.md
@@ -12,9 +12,11 @@ For `SASL EXTERNAL` to work, you must connect over TLS.
 
 ## Ensuring all created files and directories and non world readable.
 
-To make sure you are the only one who has access to the files your are about to create first run this command:
+To make sure you are the only one who has access to the files your are about to create, first run this command:
 
     umask 077
+    
+ This command will affect all files and directories created during that shell-session.
     
 
 ## Creating a self-signed certificate

--- a/content/_guides/certfp.md
+++ b/content/_guides/certfp.md
@@ -10,6 +10,13 @@ automatically.
 
 For `SASL EXTERNAL` to work, you must connect over TLS.
 
+## Ensuring all created files and directories and non world readable.
+
+To make sure you are the only one who has access to the files your are about to create first run this command:
+
+    umask 077
+    
+
 ## Creating a self-signed certificate
 
 In order to follow these instructions, you will need the `openssl` utility. If


### PR DESCRIPTION
TLDR; Ensure all file permissions are non world-readable by using umask.

I noticed that after following the instructions over here:
https://github.com/Libera-Chat/libera-chat.github.io/blob/main/content/_guides/certfp.md

The file permissions we not sufficiently restrictive.
```
openssl req -x509 -new -newkey rsa:4096 -sha256 -days 1096 -nodes -out libera.pem -keyout libera.pem
Generating a 4096 bit RSA private key
[snip]                                                                     
han@dahud ~/.irssi/ssl % ls -l libera.pem
-rw-r--r-- 1 han boetes 5.2K May 22 09:34 libera.pem
```

After discussing the matter on the #libera channel, the standard openssl version on Linux does not have this problem, and I'm running openbsd.

But IMHO it wouldn't hurt at all to mention file permission security. The proposed change will also affect directory permissions.