### PR TITLE
Add a KiwiIRC.com link to the connection list.

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -20,7 +20,9 @@
 - name: Connect
   highlight: true
   items:
-  # - name: Webchat
+  - name: Webchat
+    link: https://kiwiirc.com/nextclient/irc.libera.chat:+6697/
+    external: true
   - name: irc.libera.chat:6697 (TLS)
     link: ircs://irc.libera.chat:6697
   - name: irc.libera.chat:6667 (plaintext)

--- a/content/_posts/2021-05-25-one-week-of-libera-chat.md
+++ b/content/_posts/2021-05-25-one-week-of-libera-chat.md
@@ -41,7 +41,8 @@ PPS: We keep hearing "we will wait with contacting you as you must be
 overworked, right now" a lot. We've established a ticketing system in order to
 improve our ability to process requests. Simply send your request by email, you
 will no longer have to worry about it, we can get back to you easily, and we
-can plan our capacities better.
+can plan our capacities better. For more information, please visit our page on
+[project registration](https://libera.chat/chanreg#registering-a-channel).
 
 [1]: https://lists.ubuntu.com/archives/ubuntu-irc/2021-May/001923.html
 [2]: https://www.postgresql.org/about/news/migration-of-postgresql-irc-channels-2216/


### PR DESCRIPTION
Obviously staff are very busy right now so they haven't got around to setting up a more permanent solution for web chat so this is a temporary solution that allows people who were previously using the freenode KiwiIRC web chat to have a way to follow the channels that are moving.