### PR TITLE
README.md: Several minor fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,35 +4,37 @@
 
 ### Content
 
-- Use british english
-- Channel names, channel modes, IRC verbs, IRC commands should be escaped
-  as code, for example: `/join #libera`
-- Filenames will be the url slug, use lowercase alphanumeric characters
-  and no underscores.
-- In examples, mark required arguments with `<>` and optional arguments
-  with `[]`
-- Lines should be no longer than 80 characters
+- Use British English
+- Channel names, nicknames, channel modes, user modes, IRC verbs, and IRC
+  commands should be escaped (as code), for example: `/join #libera`
+- Filenames will be the URL slug; use lowercase alphanumeric characters and
+  no underscores
+- In examples, mark required arguments with `<>`, and optional arguments with
+  `[]`
+- Lines should be no longer than 78 characters, so that people in 80-column
+  terminals can edit the text without their editor "paging over" horizontally
+  when their cursor reaches the end of the line
 
 ## Code
 
-- 2 spaces of indentation in code
-- Be mindful about making the site accessible, to normal users, to people with
-  screen readers, and to people with text-only browsers.
+- Use 2 spaces of indentation in code
+- Be mindful about making the site accessible to all users, including those
+  with screen readers or text-only web browsers
 - For CSS
-  - Prefer logical properties (for example, `margin-inline-start`
-    rather than `margin-left`)
+  - Prefer logical properties (for example, `margin-inline-start` rather
+    than `margin-left`)
   - In general, lengths should be defined in `rem` units
   - CSS that is absolutely necessary to generate the layout should go in the
-    appropriate inlined css, other css should be loaded separately
+    appropriate inlined CSS; other CSS should be loaded separately
 - For JS
   - You probably don't need JavaScript
   - Format JS with standard.js
 - For HTML
   - Prefer elements with semantic meaning (for example, `<main>`, `<article>`)
 
-## License
+## Licensing
 
 The content of this project itself is licensed under the
-[Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License](./LICENSE-content.txt),
-and the underlying source code used to format and display that content is
-licensed under the [MIT license](./LICENSE-code.txt).
+[CC BY-NC-SA 4.0 International Public License](./LICENSE-content.txt), and the
+underlying source code used to format and display that content is licensed
+under the [MIT license](./LICENSE-code.txt).


### PR DESCRIPTION
- Correctly capitalise nouns and acronyms

- Mention nicknames and user modes in examples of things that should be
  quoted as code

- Use the Oxford comma

- Recommend a 78-column wrapping to make editing in 80-column terminals
  easier

  Re-wrap to this

- Avoid referring to able-bodied graphical users as "normal"

- Because there are multiple licenses, rename the License header

- Abbreviate the Creative Commons license to CC BY-NC-SA, as this is the
  recommended presentation:

  https://creativecommons.org/licenses/by-nc-sa/4.0/