### PR TITLE
Explicitly add webrick into the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,3 +29,4 @@ end
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 
 gem 'html-proofer'
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (1.7.0)
+    webrick (1.7.0)
     yell (2.2.2)
     zeitwerk (2.4.2)
 
@@ -282,6 +283,7 @@ DEPENDENCIES
   tzinfo (~> 1.2)
   tzinfo-data
   wdm (~> 0.1.1)
+  webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.19
+   2.2.20


### PR DESCRIPTION
Fixes #96. I tested it with Ruby 3 and 2.7, both worked fine.