### PR TITLE
Clearer wording of the two hours two weeks policy

### DIFF
--- a/policies.md
+++ b/policies.md
@@ -97,14 +97,14 @@ additional names to your account, but please remember that these are not
 collectibles and should not be hoarded or squatted.
 
 Nickname and account registrations expire ten weeks after they are last used.
-Accounts that are older than two weeks that were last used within two hours of
-registration will have all their nicknames considered to be expired. For
-grouped nicknames, "used" means that you were using the nickname while logged
-in to the account which owns it. For accounts, "used" means that you logged
-in to the account, regardless of the nickname you used to do so. Nicknames
-which are the primary account name expire only when the entire account is
-expired. If you know or plan to be absent for longer, please contact network
-staff in advance for potential options.
+In addition, if an account is older than two weeks and was last used within
+two hours of its registration, all its nicknames are considered to be expired.
+For grouped nicknames, "used" means that you were using the nickname while
+logged in to the account which owns it. For accounts, "used" means that you
+logged in to the account, regardless of the nickname you used to do so.
+Nicknames which are the primary account name expire only when the entire
+account is expired. If you know or plan to be absent for longer, please
+contact network staff in advance for potential options.
 
 In some cases, such as for very old accounts, we may, at our discretion,
 extend the expiry time of a nickname or account, usually not beyond 15 weeks

--- a/policies.md
+++ b/policies.md
@@ -97,8 +97,8 @@ additional names to your account, but please remember that these are not
 collectibles and should not be hoarded or squatted.
 
 Nickname and account registrations expire ten weeks after they are last used.
-Nicknames belonging to accounts that are older than two weeks but were last
-used within two hours of registration are also considered to be expired. For
+Accounts that are older than two weeks that were last used within two hours of
+registration will have all their nicknames considered to be expired. For
 grouped nicknames, "used" means that you were using the nickname while logged
 in to the account which owns it. For accounts, "used" means that you logged
 in to the account, regardless of the nickname you used to do so. Nicknames


### PR DESCRIPTION
Several people have expressed confusion at the recent two hours two weeks policy change. The old text is:

> Nicknames belonging to accounts that are older than two weeks but were last used within two hours of registration are also considered to be expired.

A common misconception is that "but were last used" refers to the nicknames being last used rather than the account being last used. This change clarifies the wording.