### PR TITLE
Add information regarding irssi CVE-2019-13045

### DIFF
--- a/content/_guides/sasl/irssi.md
+++ b/content/_guides/sasl/irssi.md
@@ -7,7 +7,7 @@ credits: web7
 The setup for SASL on Irssi differs depending on the version you have (you can
 find out by running `irssi -v` in your nearest shell).
 
-## Irssi 0.8.18 or later
+## Irssi 1.2.1 or later
 
 Recent Irssi versions include built-in SASL support via `/network`:
 
@@ -27,6 +27,19 @@ liberachat: sasl_mechanism: plain, sasl_username: TheCoolestNick, sasl_password:
 ```
 
 All three items (mechanism, username, and password) must be set.
+
+## Irssi 0.8.18 through 1.2.0
+
+These versions have built-in SASL support as listed for version 1.2.1 or later
+above, but _may_ have a [memory corruption bug][CVE-2019-13045] that can cause
+reconnections to fail, and strange login attempts to be registered at IRC
+servers from your client.  If your version is affected, an upgrade is
+recommended.  Any of the versions of irssi that have been fixed may follow the
+instructions for version 1.2.1 or later.
+
+Fixed in: 1.0.8, or 1.1.3, or _1.2.1 and later_.
+
+[CVE-2019-13045]: https://irssi.org/security/irssi_sa_2019_06.txt
 
 ## Older versions
 


### PR DESCRIPTION
Hi, suggesting some comments about this issue with irssi and SASL, which affects Debian buster (stable) and stretch (oldstable) right now, at least.