### PR TITLE
Fix a broken URL in FAQ

### DIFF
--- a/content/_guides/faq.md
+++ b/content/_guides/faq.md
@@ -9,7 +9,7 @@ category: about-irc
 ## You need to identify via SASL to use this server
 
 You have tried to connect from a
-[SASL access only range](guides/sasl#sasl-access-only-ip-ranges)
+[SASL access only range](/guides/sasl#sasl-access-only-ip-ranges)
 
 ## Cannot send to nick/channel
 


### PR DESCRIPTION
It's giving HTTP 404 as `/guides/guides/sasl` doesn't exist, this should fix it.