### PR TITLE
Fixes #85 -- change config so that all pages work with trailing slash

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ irc:
 
 collections_dir: content
 
-permalink: /:name
+permalink: /:name/
 
 collections:
   guides:


### PR DESCRIPTION
Fixed #85 

As per issue #85 - currently pages do not work if you add a trailing slash. The extremely simple solution for this is to make a one character change to `config.yml`.

`- permalink: /:name`

to:

`- permalink: /:name/`

This will ensure that all pages work both with *and* without a trailing slash. It does not break any of the existing layout and no further changes would be required to support this. I have tested every link on the site and none are broken as a result.