### PR TITLE
Add permalink for 404.md to make GitHub pages serve it

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,5 +1,6 @@
 ---
 title: "404"
+permalink: /404.html
 sitemap: false
 robots: noindex
 ---


### PR DESCRIPTION
I think my previous pull request, #131, led to GitHub pages not automatically recognising 404.md as the 404 page. This change will fix it so that the Libera 404 page is used, instead of the GitHub Pages default 404 page, which is currently being served.