### PR TITLE
Convert full path urls to internal links in lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,6 +50,6 @@ jobs:
           key: ${{ runner.os }}-htmlproofer
       - run: echo "::add-matcher::.github/workflow-support/htmlproofer-matcher.json"
       - name: Check for broken links
-        run: bundle exec htmlproofer --assume-extension ./_site
+        run: bundle exec htmlproofer --url-swap "https\://libera.chat:" --assume-extension ./_site
       - run: echo "::remove-matcher owner=htmlproofer::"
         if: success() || failure()


### PR DESCRIPTION
Various urls, especially those generated by jekyll SEO must be absolute
urls, e.g. the canonical tag.

If adding a new page, this is unfortunate. This change ensures
htmlproofer considers external references to our domain as internal
links.

See also https://github.com/gjtorikian/html-proofer/issues/170