### PR TITLE
Extend nickname expiration to 20 weeks

### DIFF
--- a/policies.md
+++ b/policies.md
@@ -98,10 +98,10 @@ collectibles and should not be hoarded or squatted.
 
 ### Nickname Expiration
 
-- Account names expire when the whole account has been unused for more than 10
+- Account names expire when the whole account has been unused for more than 20
   weeks.
 - Additional grouped nicknames expire when the grouped nickname has been
-  unused for more than 10 weeks.
+  unused for more than 20 weeks.
 - *Special case:* Whole accounts used for less than 2 hours after creation
   expire after 2 weeks.
 

--- a/policies.md
+++ b/policies.md
@@ -109,7 +109,7 @@ If you will be absent for longer than normal expiration times, please contact
 network staff in advance for potential options.
 
 Expiration times can be extended by staff for other reasons including account
-age to as much as 15 weeks past the last use. In rare cases, staff might deny
+age to as much as 30 weeks past the last use. In rare cases, staff might deny
 a drop request. Accounts marked "Hold" in NickServ INFO output do not expire.
 
 Nicknames and accounts which are expired will not automatically be dropped.


### PR DESCRIPTION
Update our nickname expiry policy from 10 to 20 weeks in the routine
case.