### PR TITLE
Show user-facing help for alis

### DIFF
--- a/content/_guides/findingchannels.md
+++ b/content/_guides/findingchannels.md
@@ -26,6 +26,7 @@ the following help text:
 
 ```irc
 ***** alis Help *****
+
 Help for LIST:
 
 LIST gives a list of channels matching the
@@ -40,21 +41,20 @@ Options are:
     -show [m][t]: show modes/topicsetter
     -mode <+|-|=><modes>: modes set/unset/equal
     -topic <pattern>: topic matches pattern
-    -showsecret: show secret channels (requires chan:auspex)
 
 The pattern can contain * and ? wildcards. The pattern has to
 match the full channel name or a full topic, depending on where it
 is used; the wildcards are important. The pattern is also
 automatically surrounded by * wildcards if
-a channel name pattern does not start with a wildcard or a #, or
-a topic pattern contains no * wildcards.
+- a channel name pattern does not start with a wildcard or a #, or
+- a topic pattern contains no * wildcards.
 
 For example, for channel names, from most to least specific:
-?bar       - any character followed by "bar" with no other characters
-#bar*      - anything starting with "#bar"
-##*bar*    - anything starting with ## and containing "bar"
-*cows*moo* - anything containing "cows", 0 or more characters, and "moo"
-*bar*      - anything containing "bar" (equivalent to "bar")
+ ?bar       - any character followed by "bar" with no other characters
+ #bar*      - anything starting with "#bar"
+ ##*bar*    - anything starting with ## and containing "bar"
+ *cows*moo* - anything containing "cows", 0 or more characters, and "moo"
+ *bar*      - anything containing "bar" (equivalent to "bar")
 
 Examples:
     /msg alis LIST searchterm
@@ -64,6 +64,7 @@ Examples:
     /msg alis LIST #foo* -mode =n
     /msg alis LIST *freetopic* -mode -t -show mt
     /msg alis LIST ##nocolors* -mode +c -show t
+
 ***** End of Help *****
 ```
 


### PR DESCRIPTION
Previously, the help text for `/msg alis help list` was copied out of an opered connection and therefore mentioned oper-only options (`-showsecret`). Replace with the most recent version of the user-facing help. Some spacing changes seem to have been made in the alis output; these were maintained as well in this PR.