### PR TITLE
Make clearer that forward bans work with any ban.

### DIFF
--- a/_data/channelmodes.yml
+++ b/_data/channelmodes.yml
@@ -13,7 +13,9 @@
     is supported in bans.
 
     The [second form](/guides/extbans) can be used for bans based on user
-    data. You can append `$#channel` to any ban to redirect banned users to
+    data.
+    
+    You can append `$#channel` to any ban to redirect banned users to
     another channel.
 - mode: c
   name: colour filter


### PR DESCRIPTION
The lack of paragraph separation between made it look like forwards are only supported for extbans at first glance.