### PR TITLE
Edit ERC guide for brevity and make CI happy

### DIFF
--- a/content/_guides/certfp.md
+++ b/content/_guides/certfp.md
@@ -112,7 +112,7 @@ and then reconnect to Libera.Chat.
 
 ### znc
 
-Refer to znc's [official documentation](http://wiki.znc.in/Cert).
+Refer to znc's [official documentation](https://wiki.znc.in/Cert).
 
 ### HexChat
 

--- a/content/_guides/sasl.md
+++ b/content/_guides/sasl.md
@@ -37,7 +37,7 @@ not support `DH-BLOWFISH`
 - [Revolution](/guides/revolution)
 - [Textual](/guides/textual)
 - [WeeChat](/guides/weechat)
-- [ZNC](http://wiki.znc.in/Sasl#Example)
+- [ZNC](https://wiki.znc.in/Sasl#Example)
 - [IRCCloud](/guides/irccloud)
 
 If you know of any additions or corrections to the lists above, or would like
@@ -66,8 +66,8 @@ work campuses. If you are concerned about access point privacy, you can
 
 Connecting bots which lack SASL support from SASL access only ranges can be
 achieved if you connect the bot via a bouncer that does support SASL
-authentication. [ZNC](https://wiki.znc.in) is a popular bouncer that supports
-SASL.
+authentication. [ZNC](https://wiki.znc.in/ZNC) is a popular bouncer that
+supports SASL.
 
 SASL access only restrictions are typically applied to address ranges that are
 the source of frequent policy violations due to providing easy access to

--- a/content/_guides/sasl/emacs-erc.md
+++ b/content/_guides/sasl/emacs-erc.md
@@ -3,125 +3,14 @@ title: Configuring SASL for Emacs ERC
 category: sasl
 ---
 
-[ERC](https://www.emacswiki.org/emacs/ERC) is an IRC client which comes as a package for Emacs.
+These instructions were originally contributed by androclus. Thanks!
 
-## Set up ERC IRC client
+[ERC](https://www.emacswiki.org/emacs/ERC) is an IRC client which comes as a
+package for Emacs. A script is used to provide SASL support.
 
-If you have ERC already installed and running on your emacs system, then skip to [Connect for the First Time](#connect-for-the-first-time).
-
-Otherwise, set up your ERC with basic functionality, as follows:
-
-Here we will set up your emacs with a package called "ERC", which will be an IRC "client" app.
-
-Once set up, we will Using it, you can connect to libera.chat and log in for the first time, unregistered and over a non-VPN connection
-
-1. Download and Install the erc package from melpa, etc. (`M-x package-list-packages`)
-2. Set up your ERC for plain (unregistered) sign-in.
-  - There are some basic setup instructions [here](https://www.emacswiki.org/emacs/ERC)
-  - Below is my own setup (before adding the SASL stuff below), though by no means do you need all this to set up a basic ERC for yourself.
-
-```elisp
-;; ======== ERC START ==============================
-
-;; Most of these are just for convenience options. I believe the only
-;; absolutely necessary one here is the my-erc-connect() function I
-;; define for connecting.
-
-;; for auto-joining networks and channels when starting up ERC
-(require 'erc-join)
-(erc-autojoin-enable)
-
-;; Logging of conversations (mostly for when I forget to save peoples’
-;; answers when I ask a programming question).
-
-;; turn on logging
-(setq erc-log-mode t)
-;; write to log file when new text is added to a logged ERC buffer.
-(setq erc-log-write-after-insert t)
-;; write to log file after every message I send.
-(setq erc-log-write-after-send t)
-;; Include network name in the buffers
-(setq erc-rename-buffers t)
-
-;; from local erc-log.el and tweeked
-;; see also https://www.emacswiki.org/emacs/ErcLogging
-(require 'erc-log)
-(files--ensure-directory "~/.config")
-(files--ensure-directory "~/.config/erc")
-(files--ensure-directory "~/.config/erc/logs")
-(setq erc-log-channels-directory "~/.config/erc/logs/")
-(erc-log-enable)
-
-;; don't ask me for my nickserv password
-(setq erc-prompt-for-nickserv-password nil)
-
-;; A list of channels to auto-join
-(setq erc-autojoin-channels-alist
-	'(("irc.libera.chat" "#libera" "#emacs" "#erc")))
-;; OR, if NONE..
-;; (setq erc-autojoin-channels-alist nil)
-
-;; from http://www.john2x.com/emacs.html
-;; Set the prompt to use the channel name.
-(setq erc-prompt  (lambda () (concat (buffer-name) "> ")))
-
-;; beautify the text on screen
-(setq erc-fill-function 'erc-fill-static)
-(setq erc-fill-static-center 10)
-
-;; my main function for connecting to libera.chat
-;; (see also https://libera.chat/guides/connect for regional hostnames)
-(defun my-erc-connect ()
-  (interactive)
-  (erc-tls :server "irc.libera.chat" :port 6697 :nick "MYNICK" :full-name "MY NAME"))
-(global-set-key (kbd "C-c e") 'my-erc-connect)
-
-;; Channel-tracking: Convenience functions for easily flipping between channels you are logged into
-;; from https://www.emacswiki.org/emacs/ErcChannelTracking#toc8
-;; (I don't use so much anymore, actually..)
-(defvar erc-channels-to-visit nil
-    "Channels that have not yet been visited by erc-next-channel-buffer")
-(defun erc-next-channel-buffer ()
-  "Switch to the next unvisited channel. See erc-channels-to-visit"
-  (interactive)
-  (when (null erc-channels-to-visit)
-    (setq erc-channels-to-visit 
-          (remove (current-buffer) (erc-channel-list nil))))
-  (let ((target (pop erc-channels-to-visit)))
-    (if target 
-        (switch-to-buffer target))))
-(global-set-key (kbd "C-c n") 'erc-next-channel-buffer)
-;; ======== ERC END ================================
-```
-
-3. In the `my-erc-connect` command you've defined, replace `MYNICK` with your nickname you plan to use (assuming no one else uses and has registered this nick).
-4. Either shut down your emacs and restart, or evaluate all the above lines.
-
-## Connect for the First Time
-
-If you have registered a nickname with libera already, and you remember the password, then skip to [Reconfigure
-your ERC for SASL functionality](#reconfigure-your-erc-for-sasl-functionality).
-
-Otherwise, connect for the first time (unregistered), as follows:
-
-1. First, make sure you are not using a VPN to connect to libera.chat. In most cases, you won't be allowed to connect unregistered and "un-SASL'd", from a VPN. (See [our notes on IP Range restrictions](/guides/sasl#sasl-access-only-ip-ranges).) Later, once you connect as a registered user via SASL, below, you'll be able to use your VPN to connect.
-2. Connect to irc.libera.chat (unregistered), using the nick you plan to register. (You should be able to connect by using the global shortcut `C-c e` you defined above.)
-
-## Register a Permanent Nickname and Password
-
-Now that you are logged in, please follow our instructions [register a nickname and password](/guides/registration) while signed in. When you are done registering, return here.
-
-## Disconnect
-
-After registering, disconnect now, so you can reconfigure your ERC client.
-
-## Reconfigure your ERC for SASL functionality
-
-Here we will reconfigure your ERC to add in SASL functionality using your registration credentials.
-
-1. Download a copy of erc-sasl.el from [Sylvain Benner's GitHub Repo](https://github.com/syl20bnr/spacemacs/blob/master/layers/%2Bchat/erc/local/erc-sasl/erc-sasl.el). (Note-1)
-2. Save it into one of the directorys listed in your emacs’ *load-path* variable. (Note-2)
-3. Add the following to your .emacs or init.el file in your ERC section (Note-3).
+1. Download [erc-sasl.el from GitHub](https://github.com/syl20bnr/spacemacs/blob/master/layers/%2Bchat/erc/local/erc-sasl/erc-sasl.el).
+2. Save it into one of the directories listed in your emacs `load-path`.
+3. Add the following to your `.emacs` or `init.el` file in your ERC section:
 
 ```elisp
 ;; Require ERC-SASL package
@@ -155,26 +44,18 @@ Here we will reconfigure your ERC to add in SASL functionality using your regist
   (erc-update-mode-line))
 ```
 
-4. Change the already-existing connection function you had above, so that it now includes the password you registered
+4. Update your connection function to include your NickServ password, for
+  example when using [erc-tls](https://www.emacswiki.org/emacs/ErcSSL):
 
 ```elisp
-(defun my-erc-connect ()
-  (interactive)
-  (erc-tls :server "irc.libera.chat" :port 6697 :nick "NICKNAME" :full-name "MY FULL NAME" :password "PASSWORD"))
-(global-set-key (kbd "C-c e") 'my-erc-connect)
+(erc-tls :server "irc.libera.chat" :port 6697 :nick "YourNick"
+    :full-name "Text to display as your realname/gecos"
+    :password "NickServPassword"))
 ```
 
-## Reconnect and Test
+This guide makes use of content adapted from John2x's
+[answer on StackExchange](https://emacs.stackexchange.com/questions/47572/how-to-open-an-irc-session-using-sasl),
+licensed under [CC-BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
 
-Either close down your emacs completely and restart, or evaluate the lines you added, above, including re-evaluating the `my-erc-connect` function, and try logging in via SASL, again via your `my-erc-connect` shortcut.
-
-## Notes
-
-- Note-1: If Sylvain’s repo happens to be deleted by the time you read this, then a back-up location is [psachin's gitlab repo](https://gitlab.com/psachin/erc-sasl). The erc-sasl.el there is exactly the same, with one exception: You'll need to change line 54's "loop" to read "cl-loop" (or macro/alias the former to the latter, as some folks do, because cl-loop is a Common Lisp function):
-
-```elisp
-   (cl-loop for re in erc-sasl-server-regexp-list
-```
-
-- Note-2: In my case, I saved it to ~/jeff/.emacs.d/elisp/erc-sasl.el because ~/jeff/.emacs.d/elisp/ directory is on my emacs’ `load-path`.
-- Note-3: Thanks to John2x ([his home page](https://www.john2x.com/emacs.html), [his answer on StackExchange](https://emacs.stackexchange.com/questions/47572/how-to-open-an-irc-session-using-sasl)).
+Additional helpful ERC configuration advice may be found on
+[John2x's home page](https://www.john2x.com/emacs.html).

--- a/content/_guides/sasl/emacs-erc.md
+++ b/content/_guides/sasl/emacs-erc.md
@@ -10,7 +10,6 @@ package for Emacs. A script is used to provide SASL support; you should first
 download [erc-sasl.el from GitHub](https://github.com/syl20bnr/spacemacs/blob/master/layers/%2Bchat/erc/local/erc-sasl/erc-sasl.el)
 and save it into one of the directories listed in your emacs `load-path`.
 
-
 Once the script is downloaded, add the following to your `.emacs` or `init.el`
 file in your ERC section:
 

--- a/content/_guides/sasl/emacs-erc.md
+++ b/content/_guides/sasl/emacs-erc.md
@@ -6,11 +6,13 @@ category: sasl
 These instructions were originally contributed by androclus. Thanks!
 
 [ERC](https://www.emacswiki.org/emacs/ERC) is an IRC client which comes as a
-package for Emacs. A script is used to provide SASL support.
+package for Emacs. A script is used to provide SASL support; you should first
+download [erc-sasl.el from GitHub](https://github.com/syl20bnr/spacemacs/blob/master/layers/%2Bchat/erc/local/erc-sasl/erc-sasl.el)
+and save it into one of the directories listed in your emacs `load-path`.
 
-1. Download [erc-sasl.el from GitHub](https://github.com/syl20bnr/spacemacs/blob/master/layers/%2Bchat/erc/local/erc-sasl/erc-sasl.el).
-2. Save it into one of the directories listed in your emacs `load-path`.
-3. Add the following to your `.emacs` or `init.el` file in your ERC section:
+
+Once the script is downloaded, add the following to your `.emacs` or `init.el`
+file in your ERC section:
 
 ```elisp
 ;; Require ERC-SASL package
@@ -44,8 +46,8 @@ package for Emacs. A script is used to provide SASL support.
   (erc-update-mode-line))
 ```
 
-4. Update your connection function to include your NickServ password, for
-  example when using [erc-tls](https://www.emacswiki.org/emacs/ErcSSL):
+Finally, update your connection function to include your NickServ password,
+for example when using [erc-tls](https://www.emacswiki.org/emacs/ErcSSL):
 
 ```elisp
 (erc-tls :server "irc.libera.chat" :port 6697 :nick "YourNick"

--- a/content/_minutes/2021-12-17-mgm-minutes.md
+++ b/content/_minutes/2021-12-17-mgm-minutes.md
@@ -5,4 +5,5 @@ excerpt: >
   Short meeting where nothing was discussed (holidays)
 ---
 
-No new changes or policy decisions were made in this meeting on account of most staff taking a break for the holidays.
+No new changes or policy decisions were made in this meeting on account of
+most staff taking a break for the holidays.


### PR DESCRIPTION
The SASL guides are "how to set up SASL on your client" and not "how to
set up your client from scratch" -- we assume people have a working
client and just need to enable SASL on it. As such, eliminate much of
the wording in the ERC guide that has absolutely nothing to do with
SASL.

The ERC guide and a handful of other pages were modified in order to
conform to the style guide and fix up some links that caused
redirections (and therefore htmlproofer fails).