### PR TITLE
replace kramdown with GFM

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -74,5 +74,7 @@ plugins:
   - jekyll-seo-tag
   - jekyll-sitemap
 
+markdown: GFM
+
 include:
   - .well-known

--- a/_includes/modetable.md
+++ b/_includes/modetable.md
@@ -1,33 +1,29 @@
 <!-- markdownlint-disable MD033 MD041 -->
-{::nomarkdown}<div class="table">{:/}
+<div class="table">
 
 <table>
-  <thead>
-    <tr>
-      {% if include.modes[0].type %}
-      <th>Type (name)</th>
-      {% else %}
-      <th>Mode (name)</th>
-      {% endif %}
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for mode in include.modes %}
-    <tr>
-      <td>
-        {% if mode.type %}
-        <code>{{ mode.type }}</code>
-        {% else %}
-        <code>{{ mode.mode }}</code>
-        {% endif %}
-        <br/>
-        {{ mode.name }}
-      </td>
-      <td>{{ mode.description | markdownify }}</td>
-    </tr>
-    {% endfor %}
-  </tbody>
+<thead>
+<tr>
+{% if include.modes[0].type %}
+<th>Type (name)</th>
+{% else %}
+<th>Mode (name)</th>
+{% endif %}
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+{% for mode in include.modes %}
+<tr>
+<td>
+{% if mode.type %}<code>{{ mode.type }}</code>{% else %}<code>{{ mode.mode }}</code>{% endif %}
+<br/>
+{{ mode.name }}
+</td>
+<td>{{ mode.description | markdownify }}</td>
+</tr>
+{% endfor %}
+</tbody>
 </table>
 
-{::nomarkdown}</div>{:/}
+</div>

--- a/content/_guides/connect.md
+++ b/content/_guides/connect.md
@@ -11,6 +11,7 @@ Connect to Libera.Chat with TLS at `irc.libera.chat` on port `6697`.
 
 Additional regional and address-specific hostnames are available:
 
+|                           |                        |
 | ------------------------- | ---------------------- |
 | Default                   | `irc.libera.chat`      |
 | Europe                    | `irc.eu.libera.chat`   |
@@ -22,6 +23,7 @@ Additional regional and address-specific hostnames are available:
 
 Additional ports are available:
 
+|            |                      |
 | ---------- | -------------------- |
 | Plain-text | 6665-6667, 8000-8002 |
 | TLS        | 6697, 7000, 7070     |

--- a/sponsors.md
+++ b/sponsors.md
@@ -6,36 +6,29 @@ Libera Chat is run thanks to a number of people, projects, and organisations
 who provide both time and resources to Libera Chat. Without them none of this
 would be possible
 
-{::nomarkdown}
 <!-- markdownlint-disable MD013 MD033 -->
 
 <div class="sponsors">
-  {% assign current_sponsors = site.data.sponsors | where: 'current', true %}
-  {% for sponsor in current_sponsors %}
-  <a href="{{ sponsor.link }}" {% if sponsor.skip_htmlproofer %}data-proofer-ignore {% endif %}rel="noopener noreferrer">
-    {% if sponsor.image %}
-    {% if sponsor.sources %}
-    <picture>
-    {% for source in sponsor.sources %}
-    <source
-      srcset="{{ source.srcset }}"
-      {% if source.type %}type="{{ source.type }}"{% endif %}
-      {% if source.media %}media="{{ source.media }}"{% endif %}
-    >
-    {% endfor %}
-    {% endif %}
-    <img src="{{ sponsor.image }}" alt="{{ sponsor.name }}" loading="lazy" height="64" />
-    {% if sponsor.sources %}
-    </picture>
-    {% endif %}
-    {% else %}
-    {{ sponsor.name }}
-    {% endif %}
-  </a>
-  {% endfor %}
+{% assign current_sponsors = site.data.sponsors | where: 'current', true %}
+{% for sponsor in current_sponsors %}
+<a href="{{ sponsor.link }}" {% if sponsor.skip_htmlproofer %}data-proofer-ignore {% endif %}rel="noopener noreferrer">
+{% if sponsor.image %}
+{% if sponsor.sources %}
+<picture>
+{% for source in sponsor.sources %}
+<source srcset="{{ source.srcset }}" {% if source.type %}type="{{ source.type }}"{% endif %} {% if source.media %}media="{{ source.media }}"{% endif %}>
+{% endfor %}
+{% endif %}
+<img src="{{ sponsor.image }}" alt="{{ sponsor.name }}" loading="lazy" height="64" />
+{% if sponsor.sources %}
+</picture>
+{% endif %}
+{% else %}
+{{ sponsor.name }}
+{% endif %}
+</a>
+{% endfor %}
 </div>
-
-{:/}
 
 {% assign past_sponsors = site.data.sponsors | where: 'current', false %}
 


### PR DESCRIPTION
This swaps out the default kramdown renderer in Jekyll for [GitHub pages' GFM renderer](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/setting-a-markdown-processor-for-your-github-pages-site-using-jekyll)

There are pros and cons of this, the main benefits include that if it renders on GH when looking at a PR or commit, it will render the same on the site once it's deployed (something I noticed in the 2022-01 minutes where the code blocks in `<details>` rendered in GH, and to my knowledge would render as expected in jekyll, and then didn't)

Most downsides I'm aware of are covered by the code changes in this PR:
- markdown tables MUST have headers
- inline-html cannot be indented (and there's no `{::nomarkdown}` to get around it)