### PR TITLE
Add SASL instructions for catgirl

### DIFF
--- a/content/_guides/sasl.md
+++ b/content/_guides/sasl.md
@@ -22,6 +22,7 @@ not support `DH-BLOWFISH`
 
 - [AdiIRC](https://dev.adiirc.com/projects/adiirc/wiki/SASL)
 - [AndroIRC](https://web.archive.org/web/20210319221818/http://wiki.androirc.com/nickserv_sasl)
+- [catgirl](/guides/catgirl)
 - [Chatzilla](/guides/chatzilla)
 - [Emacs ERC](/guides/emacs-erc)
 - [EPIC5](/guides/epic5)

--- a/content/_guides/sasl/catgirl.md
+++ b/content/_guides/sasl/catgirl.md
@@ -1,0 +1,16 @@
+---
+title: Configuring SASL for catgirl
+category: sasl
+---
+
+To connect to Libera.Chat using SASL PLAIN on catgirl, choose one of the
+following options:
+
+- Add SASL PLAIN as a config file option with username and password:
+  `sasl-plain = username:password`
+- Add SASL PLAIN as a config file option with just username (catgirl 2.1+
+  only, will prompt for password on connect): `sasl-plain = username:`
+- Add SASL PLAIN as a command-line argument: `catgirl -a username:password`
+
+To connect to Libera.Chat using SASL EXTERNAL on catgirl,
+[see the manpage](https://git.causal.agency/catgirl/about/catgirl.1#Configuring_CertFP).


### PR DESCRIPTION
Adds SASL instructions for [catgirl](https://git.causal.agency/catgirl/about/), a cute and opinionated TUI IRC client.

(I ran the instructions past the client author before PRing, she says they look fine. I have not built the website locally to make sure they're formatted correctly.)