### PR TITLE
Add catgirl to clients page

### DIFF
--- a/content/_guides/clients.md
+++ b/content/_guides/clients.md
@@ -62,3 +62,4 @@ Both of these are free and run under Linux, macOS, and Windows (using WSL or Cyg
 
 - [Irssi](https://irssi.org/)
 - [WeeChat](https://weechat.org/)
+- [catgirl](https://git.causal.agency/catgirl/about/)


### PR DESCRIPTION
Adds a clients page entry for [catgirl](https://git.causal.agency/catgirl/about/), a cute and opinionated TUI IRC client.

I split this into a separate PR from #214 because I have no idea what the criteria are for adding a client to this page, and didn't want to block merging SASL instructions on a debate about this.