### PR TITLE
Update findingchannels.md

### DIFF
--- a/content/_guides/findingchannels.md
+++ b/content/_guides/findingchannels.md
@@ -19,7 +19,7 @@ whose name contains the term in question - for instance,
 You can also search on the channel's current topic, require a minimum number of
 users (to weed out barely-used channels), and use various wildcards to control
 your search - for instance, `/msg alis LIST #libera* -min 10` would find all
-channels in the Libera.Chat namespace with at least 10 users.
+channels whose names begin with `#libera` and which have at least 10 users.
 
 For full details on how to use alis, `/msg alis HELP LIST` will send you back
 the following help text:


### PR DESCRIPTION
We don't explain what a namespace is anywhere on this page, and while I could link that to `/chanreg` instead, it feels like superfluous information for a newbie trying to discover channels on the network. As such, re-word the example to remove the mention of channel namespaces.