### PR TITLE
sasl.md: Some IP ranges are exempt from sasl on webchat.

### DIFF
--- a/content/_guides/sasl.md
+++ b/content/_guides/sasl.md
@@ -58,10 +58,11 @@ existing NickServ account with a **verified email address**. Connections from
 these ranges will be refused with the message `SASL access only`. You can
 follow the instructions above to configure many commonly used clients.
 
-Our webchat clients use SASL authentication when a password is provided, but
-they are **no longer exempt** from the SASL access only restriction. You will
-need to find an alternative connection to register your account on before
-swapping to using the SASL access only connection.
+Our webchat clients use SASL authentication when a password is provided, but 
+some IP ranges are **no longer exempt** from the SASL access only restriction. 
+If your IP range is not exempt you will need to find an alternative connection 
+to register your account on before swapping to using the SASL access only 
+connection.
 
 If your home internet providers are restricted, consider using public access
 wifi hotspots such as those provided by most libraries and many school or


### PR DESCRIPTION

UTC-4  May 17, 2022 #libera
```
[00:32:57] <KindOne> https://libera.chat/guides/sasl#sasl-access-only-ip-ranges - "Our webchat clients use SASL authentication when a password is provided, but they are no longer exempt from the SASL access only restriction."  Am I reading this wrong or is the text itself wrong? My IPv6 address has a sasl requirment if i try from irssi, but webchat works just fine without sasl.
[00:52:27] <@el> KindOne: some are some aren't.
[00:52:56] <@el> so they're no longer exempt as a rule, which was the case.
[00:54:09] <KindOne> Should it be reworded?
[00:54:30] <@el> very likely
[00:54:41] <@el> if you figure one out make a PR
```