### PR TITLE
make collective staff authorship use a uniform name

### DIFF
--- a/content/_posts/2021-12-20-end-of-2021-review.md
+++ b/content/_posts/2021-12-20-end-of-2021-review.md
@@ -1,6 +1,6 @@
 ---
 title: 2021 Libera end of year review
-author: Libera staff
+author: staff
 ---
 
 Hello everyone!

--- a/content/_posts/2022-05-19-happy-birthday-libera-chat.md
+++ b/content/_posts/2022-05-19-happy-birthday-libera-chat.md
@@ -1,6 +1,6 @@
 ---
 title: Happy Birthday, Libera Chat!
-author: Libera staff
+author: staff
 ---
 
 Hello everyone,


### PR DESCRIPTION
the first blog post uses `staff`. i think we should avoid using `Libera` instead of `Libera Chat`, and i think naming which staff are writing a blog post is redundant given it's on our site