### PR TITLE
bots.md: specify litharge requirements

### DIFF
--- a/content/_guides/bots.md
+++ b/content/_guides/bots.md
@@ -38,6 +38,8 @@ This bot will need the `+o` flag in your channel so that it can op itself to
 remove bans when they expire; `/msg chanserv flags #yourchannel litharge +o`.
 
 When requesting litharge for your channel, simply `/invite litharge #yourchannel`.
+At least 10 users must be present in the channel for litharge to join and
+your channel must not be [`+s`](/guides/channelmodes).
 
 ### Usage
 


### PR DESCRIPTION
Stumbled upon this when trying to get litharge to join my channel which is +s. moonmoon in -dev clarified the requirement is 10 users and -s.

We also found a bug in ChanTracker because I did not get any error message when I tried to invite it to my 65 people +s chan.
Quote:

```
20:21 <moonmoon> if you feel like doing some python, the reason you didn't get any response is because https://github.com/ncoevoet/CheckInvite/blob/master/plugin.py hooks the list reply for the error message on < 10 users, but +s channels won't issue that numeric at all
20:22 <moonmoon> so would need to hook the end of list numeric and somehow know that no response was issued
20:22 <moonmoon> either that or issue a MODE on the channel and look for +s
```

In any case, the only other thing I can think of is clarifying it even further, whether 10 users are needed constantly or only on the initial join or something. This is something I am not sure on myself but this is an edgecase to consider.