### PR TITLE
Extend pidgin SASL guide to include setting SASL login name

### DIFF
--- a/content/_guides/sasl/pidgin.md
+++ b/content/_guides/sasl/pidgin.md
@@ -15,7 +15,10 @@ If you have already added Libera.Chat as an account, skip to step 5.
    `Remember password`
 6. Click on to the `Advanced` tab
 7. Change `Port` to `6697`, tick `Use SSL` and `Authenticate with SASL`
-8. If this is a newly created Pidgin account, click `Add` and pidgin will
+8. Enter your Libera.Chat account name as `SASL login name`. This ensures that
+   the correct username is used to login in cases where you have set `Real name`
+   to something other than your Libera.Chat account name.
+9. If this is a newly created Pidgin account, click `Add` and pidgin will
    begin to connect
-9. If this is an existing account, click `Save`, then restart Pidgin for the
+10. If this is an existing account, click `Save`, then restart Pidgin for the
    SASL settings to take effect.


### PR DESCRIPTION
The other day a user in #pidgin followed this guide and had problems logging in because they had set `Real name` to their full name and no `SASL login name`. Pidgin uses `Real name` as fallback for login, so setting `SASL login name` fixed the login problems.