### PR TITLE
Add Atom link tag in head

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,6 +10,7 @@
   <meta name="robots" content="{{ page.robots }}">
   {%- endif -%}
   {%- seo -%}
+  <link rel="alternate" type="application/atom+xml" title="{{ site.title }} News" href="/atom.xml">
   <link rel="icon" type="image/svg+xml" href="/static/img/libera-color.svg">
   <link rel="alternate icon" href="/favicon.ico">
   <!-- Stylesheets -->


### PR DESCRIPTION
This helps feed discoverability for compatible clients, allowing a user for example to point an RSS reader directly to the website.

Some browsers also detect the feed automatically.
![feed](https://user-images.githubusercontent.com/6003656/205499691-e14defa2-63af-4482-a68d-38d723a5dbfe.png)
