### PR TITLE
Automatically update privacy policy last modified

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -17,6 +17,9 @@ jobs:
           ruby-version: '3.0' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
+      - name: Define additional Jekyll variables
+        run: |
+          echo "privacy_last_modified: $(git log -1 --format=%cd --date=short -- privacy.md)" >> _config.yml
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"

--- a/privacy.md
+++ b/privacy.md
@@ -2,7 +2,7 @@
 title: Privacy
 ---
 
-This page was last updated 2022-05-04.
+This page was last updated {% site.privacy_last_modified %} ([history][hist]).
 
 Libera Chat is a non-profit organisation based in Sweden (org.nr. 802535-6448).
 Libera Chat operates the Libera Chat IRC network, and the website Libera.Chat,
@@ -113,3 +113,4 @@ For any inquiries or concerns about how Libera Chat process your data,
 please email <policy@libera.chat>.
 
 [imy]: https://www.imy.se/en/
+[hist]: https://github.com/Libera-Chat/libera-chat.github.io/commits/main/privacy.md


### PR DESCRIPTION
This is a bit of a hacky workaround, but it seemed better than adding a dependency to the seemingly-abandoned jekyll-last-modified-at gem. This will store an additional configuration variable containing the last modified date in YYYY-mm-dd format to _config.yml, so that jekyll can pull that and render it in the page.

Additionally, the full privacy policy history is now linked adjacent to the last modified date, so people can easily check on what has changed with the policy.