### PR TITLE
fix whitespace being considered part of <a> in blog post permalinks

### DIFF
--- a/_includes/article.html
+++ b/_includes/article.html
@@ -6,9 +6,7 @@
   {% endif %}
 
   <p class="details">
-    <a href="{{ include.article.url }}">
-      <time pubdate datetime="{{ include.article.date | date: "%Y-%m-%d" }}">{{ include.article.date | date_to_long_string: "ordinal", "GB" }}</time>
-    </a>
+    <a href="{{ include.article.url }}"><time pubdate datetime="{{ include.article.date | date: "%Y-%m-%d" }}">{{ include.article.date | date_to_long_string: "ordinal", "GB" }}</time></a>
     {% if include.article.author %}
     by {{ include.article.author }}
     {% endif %}


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/11245819/218350855-1830893d-0d77-4e78-bb26-f0eb874e89bd.png)

after:
![image](https://user-images.githubusercontent.com/11245819/218350903-572bb9bc-4e02-4d1e-8bb6-2424cf57c4ef.png)
