### PR TITLE
faq.md: mention NickServ BADPASSWDMSG in place of outdated info

### DIFF
--- a/content/_guides/faq.md
+++ b/content/_guides/faq.md
@@ -184,9 +184,9 @@ expired again.
 
 ## Why are people trying to log in as me?
 
-Sometimes you might get alerts from NickServ or SaslServ about attempts to log
-in to your account. These alerts are almost always caused by clients that are
-misconfigured.
+When you have `BADPASSWDMSG` enabled, you might get alerts from NickServ or SaslServ
+about attempts to log in to your account. These alerts are almost always caused by
+clients that are misconfigured.
 
 If you have lots of nicks grouped or if you have a common name or word
 grouped, you will get an above average number of alerts.
@@ -195,10 +195,14 @@ You do not need to worry if you have chosen a strong password that is not used
 in other places.
 
 If the attempts are very frequent and persistent, feel welcome to let staff
-know, just in case.
+know, just in case. Libera.Chat does stop actual bruteforce attacks and
+these messages were [disabled by default](https://libera.chat/news/badpasswdmsg-default),
+due to excessive noise. To disable them:
 
-_At your own risk_, you can mute these alerts.
-See `/msg Nickserv HELP SET BADPASSWDMSG`.
+
+```irc
+/msg Nickserv SET BADPASSWDMSG OFF
+```
 
 ## Warez or Adult content sharing?
 

--- a/content/_guides/faq.md
+++ b/content/_guides/faq.md
@@ -197,8 +197,8 @@ in other places.
 If the attempts are very frequent and persistent, feel welcome to let staff
 know, just in case.
 
-_At your own risk_, and depending on your client, you may be able to filter
-the alerts. Ask your client's support channel if this is possible.
+_At your own risk_, you can mute these alerts.
+See `/msg Nickserv HELP SET BADPASSWDMSG`.
 
 ## Warez or Adult content sharing?
 

--- a/content/_guides/faq.md
+++ b/content/_guides/faq.md
@@ -196,7 +196,7 @@ in other places.
 
 If the attempts are very frequent and persistent, feel welcome to let staff
 know, just in case. Libera.Chat does stop actual bruteforce attacks and
-these messages were [disabled by default](https://libera.chat/news/badpasswdmsg-default),
+these messages were [disabled by default](/news/badpasswdmsg-default),
 due to excessive noise. To disable them:
 
 ```irc

--- a/content/_guides/faq.md
+++ b/content/_guides/faq.md
@@ -184,9 +184,9 @@ expired again.
 
 ## Why are people trying to log in as me?
 
-When you have `BADPASSWDMSG` enabled, you might get alerts from NickServ or SaslServ
-about attempts to log in to your account. These alerts are almost always caused by
-clients that are misconfigured.
+When you have `BADPASSWDMSG` enabled, you might get alerts from NickServ
+or SaslServ about attempts to log in to your account. These alerts are
+almost always caused by clients that are misconfigured.
 
 If you have lots of nicks grouped or if you have a common name or word
 grouped, you will get an above average number of alerts.
@@ -198,7 +198,6 @@ If the attempts are very frequent and persistent, feel welcome to let staff
 know, just in case. Libera.Chat does stop actual bruteforce attacks and
 these messages were [disabled by default](https://libera.chat/news/badpasswdmsg-default),
 due to excessive noise. To disable them:
-
 
 ```irc
 /msg Nickserv SET BADPASSWDMSG OFF


### PR DESCRIPTION
We've got a way to do this for all clients now which is frequently mentioned in `#libera` and such. While someone was asking about just this, I had trouble finding a guide to link it to them and noticed this outdated blurb.