### PR TITLE
Ignore perpetually broken URL checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,6 +50,6 @@ jobs:
           key: ${{ runner.os }}-htmlproofer
       - run: echo "::add-matcher::.github/workflow-support/htmlproofer-matcher.json"
       - name: Check for broken links
-        run: bundle exec htmlproofer --url-swap "https\://libera.chat:" --assume-extension ./_site
+        run: bundle exec htmlproofer --url-swap "https\://libera.chat:" --assume-extension ./_site --url-ignore /liberapay.com/,/www.imy.se/
       - run: echo "::remove-matcher owner=htmlproofer::"
         if: success() || failure()


### PR DESCRIPTION
liberapay rejects the link liveness check with a 403. While we could spoof the User-Agent to bypass this, it seems better to respect their wishes to block these automated processes and just not bother checking the link in the first place.

Not sure what the issue is with imy.se, but ignore that too as it seems to be an issue with the TLS handshake (?) despite the link working fine in a browser.