### PR TITLE
Mention that connected users are not affected by +r

### DIFF
--- a/_data/channelmodes.yml
+++ b/_data/channelmodes.yml
@@ -138,6 +138,7 @@
   name: block unidentified
   description: |
     Prevents users who are not identified to services from joining the channel.
+    Users already in the channel are not affected.
 - mode: R
   name: silence unidentified
   description:


### PR DESCRIPTION
This also makes it consistent with the `S` mode explanation (which works similarly)