### PR TITLE
Add `text-wrap: balance;` to headings

### DIFF
--- a/_includes/inline-style.css
+++ b/_includes/inline-style.css
@@ -108,6 +108,7 @@ em {
 
 h1, h2, h3, h4, h5, h6 {
   margin-block-end: 0;
+  text-wrap: balance;
 }
 
 h1+*, h2+*, h3+*, h4+*, h5+*, h6+* {


### PR DESCRIPTION
CCS Text Level 4's [text-wrap balance](https://drafts.csswg.org/css-text-4/#text-wrap) is starting to roll out in [browsers](https://developer.chrome.com/blog/css-text-wrap-balance/), whilst not available in stable versions yet it's nice to be ready to have BALANCED HEADINGS!!!!