### PR TITLE
Add the Goguma Android IRC client

### DIFF
--- a/content/_guides/clients.md
+++ b/content/_guides/clients.md
@@ -52,6 +52,8 @@ iOS (paid)
 - [Palaver](https://apps.apple.com/us/app/palaver/id538073623) - iOS (paid)
 - [RevolutionIRC](https://play.google.com/store/apps/details?id=io.mrarm.irc)
 \- Android, also on [F-Droid](https://f-droid.org/packages/io.mrarm.irc/) (free)
+- [Goguma](https://sr.ht/~emersion/goguma/)
+\- Android, also on [F-Droid](https://fdroid.emersion.fr/#goguma-nightly) (free)
 
 ### Terminal clients
 


### PR DESCRIPTION
While the goal of the list is not to be exhaustive, Goguma is a simple and intuitive client that can be a great choice for new IRC users on Android.