### PR TITLE
certfp guide: ~/.weechat -> ~/.local/share/weechat

### DIFF
--- a/content/_guides/certfp.md
+++ b/content/_guides/certfp.md
@@ -89,11 +89,16 @@ certificate.
 
 ### weechat
 
-Move the certificates you created above to ~/.weechat/certs
+Note: You may need to replace ~/.local/share/weechat with ~/.weechat if the
+latter exists but the former doesn't. New WeeChat configurations use the former,
+but if your first run was on a version older than WeeChat 3.2, you would likely need
+to use ~/.weechat.
+
+Move the certificates you created above to ~/.local/share/weechat/certs
 
 ```sh
-mkdir ~/.weechat/certs
-mv libera.pem ~/.weechat/certs
+mkdir ~/.local/share/weechat/certs
+mv libera.pem ~/.local/share/weechat/certs
 ```
 
 Now disconnect and remove the current Libera.Chat server(s). Re-add it with


### PR DESCRIPTION
WeeChat configurations first created by versions older than 3.2 use
~/.weechat, while 3.2 and later use XDG directories ~/.config/weechat,
~/.local/share/weechat, and ~/.cache/weechat. See
https://blog.weechat.org/post/2021/06/12/XDG-directories.

%h, by default, points to either ~/.local/share/weechat or ~/.weechat.
Since people are likely on the newer directory structure now, which is
the default for modern versions, the CertFP guide is hereby changed to
reflect that. A note tells users to use ~/.weechat if that exists.

Signed-off-by: Runxi Yu <harriet@andrewyu.org>
