### PR TITLE
Guides: CertFP: Change recommended private key algorithm to Ed25519

### DIFF
--- a/content/_guides/certfp.md
+++ b/content/_guides/certfp.md
@@ -19,7 +19,7 @@ you are using Windows and do not have a copy, you might consider using Cygwin.
 You can generate a certificate with the following command:
 
 ```sh
-openssl req -x509 -new -newkey rsa:4096 -sha256 -days 1096 -nodes -out libera.pem -keyout libera.pem
+openssl req -x509 -new -newkey ed25519 -sha256 -days 1096 -nodes -out libera.pem -keyout libera.pem
 ```
 
 You will be prompted for various pieces of information about the certificate.


### PR DESCRIPTION
OpenSSL 1.x is now EOL and OpenSSL 3 unconditionally supports Ed25519.

Our IRC servers are also using OpenSSL 3 and so also support it.

Performing a signature with Ed25519 is also both significantly faster, and much harder for cryptographic libraries to get wrong in a manner that affects security.