### PR TITLE
Update weechat certfp guide commands for weechat v4.0.0

### DIFF
--- a/content/_guides/certfp.md
+++ b/content/_guides/certfp.md
@@ -101,6 +101,14 @@ the SSL flag, using your newly generated certificate. Note that these commands
 are just examples, you have to adapt them to your current servers.
 
 ```irc
+# For Weechat version >= 4.0.0
+/set irc.server.liberachat.addresses irc.libera.chat/6697
+/set irc.server.liberachat.tls on
+/set irc.server.liberachat.tls_verify on
+/set irc.server.liberachat.tls_cert %h/certs/libera.pem
+/set irc.server.liberachat.sasl_mechanism external
+
+# For Weechat version < 4.0.0
 /set irc.server.liberachat.addresses irc.libera.chat/6697
 /set irc.server.liberachat.ssl on
 /set irc.server.liberachat.ssl_verify on


### PR DESCRIPTION
Weechat 4.0.0 renamed the ssl_* options to tls_*. Update the guide page accordingly.

For reference, please see the Weechat 4.0.0 release notes: https://blog.weechat.org/post/2023/06/24/Version-4.0.0

> Options changed:
> 
>     option irc.server_default.ssl renamed to irc.server_default.tls
>     option irc.server_default.ssl_cert renamed to irc.server_default.tls_cert
>     option irc.server_default.ssl_dhkey_size renamed to irc.server_default.tls_dhkey_size
>     option irc.server_default.ssl_fingerprint renamed to irc.server_default.tls_fingerprint
>     option irc.server_default.ssl_password renamed to irc.server_default.tls_password
>     option irc.server_default.ssl_priorities renamed to irc.server_default.tls_priorities
>     option irc.server_default.ssl_verify renamed to irc.server_default.tls_verify
>     option relay.network.ssl_cert_key renamed to relay.network.tls_cert_key
>     option relay.network.ssl_priorities renamed to relay.network.tls_priorities
>     option weechat.color.status_name_ssl renamed to weechat.color.status_name_tls