### PR TITLE
Add name="" attribute to <details> element in main navigation

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -11,7 +11,7 @@
     <a id="nav-close" class="nav-close hidden" aria-controls="main-nav"><span>Close</span></a>
     {% for navgroup in site.data.nav %}
     {% if navgroup.items %}
-    <details>
+    <details name="main-navigation">
       <summary
         {% if navgroup.highlight %}class="highlight"{% endif %}
       >{{ navgroup.name }}</summary>


### PR DESCRIPTION
This is being tested by browsers (safari, edge, opera in preview. Stable in chrome 120) to create a native "accordion" effect only allowing one `<details>` element with the same name attribute to be open at a time