### PR TITLE
Add litharge caveat: removing permissions requires staff assistance

### DIFF
--- a/content/_guides/bots.md
+++ b/content/_guides/bots.md
@@ -108,3 +108,17 @@ with the user):
 
 That will show all users with `.com` in their hostmask being affected by any
 intended mode change.
+
+### Caveats
+
+Litharge uses [AutoRegister](https://github.com/ncoevoet/AutoRegister) to
+create accounts on the bot based on network services accounts.  Currently, the 
+controls for directly managing channel/capability associtations are restricted
+and can only be accessed by network staff.
+
+This means, when you remove flags for a user you must also request staff
+assistance to remove the corrisponding settings from litharge (given that user
+was oberved by litherage setting a ban or quiet in the given channel).
+
+See the [FAQ](https://libera.chat/guides/faq#how-to-find-libera-chat-staff) for 
+information on how to contact staff.


### PR DESCRIPTION
Follow-up from a conversation a little while back in the community channel, this change let's users know that they will need to request staff support to remove chan/op permissions from litharge.