### PR TITLE
static/css/additional-styles.css: disable line wrapping in <code>

### DIFF
--- a/static/css/additional-styles.css
+++ b/static/css/additional-styles.css
@@ -35,6 +35,7 @@ code, pre, kbd {
 code, kbd {
   padding: .1rem .3rem;
   border: 1px solid var(--c-border);
+  white-space: nowrap;
 }
 
 pre code {


### PR DESCRIPTION
before:
![image](https://github.com/Libera-Chat/libera-chat.github.io/assets/118043585/f23f841f-9d36-44b0-a844-011b941fbe34)

after:
![image](https://github.com/Libera-Chat/libera-chat.github.io/assets/118043585/08ef07b5-4de9-4f53-b730-89b97a12d2c3)
