### PR TITLE
hexchat login method label is "SASL PLAIN"

### DIFF
--- a/content/_guides/sasl/hexchat.md
+++ b/content/_guides/sasl/hexchat.md
@@ -20,7 +20,7 @@ length of __85 characters__.
    then hit enter and click on Edit
 4. Replace the string `newserver/6667` with `irc.libera.chat/+6697`
 5. In the `User name` field, enter your primary nick
-6. Select `SASL (username + password)` for the `Login method` field
+6. Select `SASL PLAIN (username + password)` for the `Login method` field
 7. In the `Password` field, enter your NickServ password
 
 If you are unable to edit the `User name` field, the change can be made in the


### PR DESCRIPTION
changed in 2.16.2: https://github.com/hexchat/hexchat/commit/9b76b557ecaece2a5fa862ea4dc75ed613e3fbf0#diff-b519a608764ab820661094eb3801e529041ddec29104172896053d389de50d0aR152