### PR TITLE
Add `/save` again to save secure password and passphrase

### DIFF
--- a/content/_guides/sasl/weechat.md
+++ b/content/_guides/sasl/weechat.md
@@ -42,6 +42,7 @@ passphrase if already set):
 /secure passphrase <passphrase>
 /secure set libera_password <password>
 /set irc.server.libera.sasl_password "${sec.data.libera_password}"
+/save
 ```
 
 For more complete instructions, including non-password-based mechanisms,


### PR DESCRIPTION
I forgot to save again, so passphrase not persisted