### PR TITLE
minor terminal punctuation fixes and monospace

### DIFF
--- a/content/_guides/connect.md
+++ b/content/_guides/connect.md
@@ -38,7 +38,7 @@ CA certificates. On most linux distributions this will be in a package named
 something like ca-certificates. Many systems install these by default, but some
 (such as FreeBSD) do not. For FreeBSD, the package is named ca\_root\_nss,
 which will install the appropriate root certificates in
-/usr/local/share/certs/ca-root-nss.crt.
+`/usr/local/share/certs/ca-root-nss.crt`.
 
 Certificate verification will generally only work when connecting to
 **`libera.chat`**. If your client thinks the server's certificate is invalid,

--- a/content/_guides/faq.md
+++ b/content/_guides/faq.md
@@ -73,7 +73,7 @@ you can enquire about the ban by sending an email to us at <bans@libera.chat>.
 ## You need to identify via SASL to use this server
 
 You have tried to connect from a
-[SASL access only range](/guides/sasl#sasl-access-only-ip-ranges)
+[SASL access only range](/guides/sasl#sasl-access-only-ip-ranges).
 
 ## Cannot send to nick/channel
 
@@ -319,7 +319,7 @@ hit connection limits or trip anti-abuse measures. Please contact
 Please consult our [Matrix FAQ](/guides/matrix) for information on connecting
 with Matrix, getting support for Matrix, and other Matrix related questions.
 
-## Can I connect with XMPP
+## Can I connect with XMPP?
 
 Third-party operated XMPP bridges are allowed on Libera.Chat, however we
 prohibit double bridging, including over XMPP. We also request that


### PR DESCRIPTION
1. Make the CA root cert path monospace to be consistent with the other guides which use monospace for paths.
2. Add missing terminal punctuation in body.
3. Add missing terminal punctuation in section heading. Yes, the anchor stays the same.