### PR TITLE
Tweak content widths for codeblocks

### DIFF
--- a/_includes/inline-hero-style.css
+++ b/_includes/inline-hero-style.css
@@ -89,7 +89,7 @@
     grid-template-areas: "logo tagline" "logo cta";
   }
   .hero .logo, .hero .tagline, .hero .cta {
-    max-width: calc(var(--content-max-width) / 1.5);
+    max-width: calc(var(--content-max-width) / 1.90);
   }
   .hero .logo {
     justify-self: end;

--- a/_includes/inline-style.css
+++ b/_includes/inline-style.css
@@ -32,7 +32,7 @@
 :root {
   --header-height: 4rem;
   --content-inline-padding: 1.3rem;
-  --content-max-width: 80ch;
+  --content-max-width: 100ch;
   /* define our palette for all themes */
   --white: #fff;
   --gray-100: #f3f4f6;
@@ -338,6 +338,10 @@ main {
   min-width: 0;
   width: 100%;
   margin: 2rem auto;
+}
+
+main.front {
+  max-width: calc(var(--content-max-width) - 20ch);
 }
 
 nav.article-nav {

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -27,7 +27,7 @@
     {%- include hero.html -%}
   {% endif %}
 
-  <main id="main">
+  <main id="main" class="front">
     {%- include article.html article=site.posts.first -%}
   </main>
 


### PR DESCRIPTION
Codeblocks, particularly for the annual report tables,
look garbage because they require scrolling. This bumps
most of the site's content-max-width to 100 from 80,
but special-cases the front page because it was awful
with those dimensions.