### PR TITLE
Clarify that an account is needed before connecting with Tor

### DIFF
--- a/content/_guides/connect.md
+++ b/content/_guides/connect.md
@@ -58,7 +58,8 @@ appear in WHOIS (a 276 numeric).
 ## Accessing Libera.Chat Via Tor
 
 Libera.Chat is reachable via [Tor](https://www.torproject.org/) using our
-[onion service](https://community.torproject.org/onion-services/).
+[onion service](https://community.torproject.org/onion-services/),
+provided you already have an account (created without using Tor).
 
 Configuration requirements with details below:
 


### PR DESCRIPTION
This is apparently not clear to everyone: https://www.reddit.com/r/irc/comments/1lnda2a/beware_irc_libera_chat_tor_option_does_not_give/