### PR TITLE
Channel modes `+v` and `+o`

### DIFF
--- a/_data/channelmodes.yml
+++ b/_data/channelmodes.yml
@@ -174,7 +174,10 @@
 - mode: v
   name: voiced
   description: |
-    Allows matching users to speak regardless of `+m` or `+q` flags.
+    Allows matching users to speak regardless of `+m` or `+q` flags. Also
+    recommended for bots that talk in channels, as it exempts matching
+    users from some channel flood controls, and will prevent network
+    staff and the network's spam-management bots from being notified.
 - mode: z
   name: reduced moderation
   description: |


### PR DESCRIPTION
Adding missing `+v` and `+o` modes, as per observation from #libera (around 2025-07-24 10:36 UTC).

**yamllint**: ✓
**hunspell**: ✓
**jekyll**: not tested (incompatible version)

Contribution released into the public domain (per CC0-1.0).